### PR TITLE
Added a RWMutex to replace the straight Mutex

### DIFF
--- a/inmem.go
+++ b/inmem.go
@@ -103,7 +103,7 @@ func (c *cache) removeElement(e *list.Element) {
 
 type lockedCache struct {
 	c cache
-	m sync.Mutex
+	m sync.RWMutex
 }
 
 // NewLocked constructs a new Cache of the given size that is safe for
@@ -128,9 +128,9 @@ func (l *lockedCache) Add(key, value interface{}, expiresAt time.Time) {
 }
 
 func (l *lockedCache) Get(key interface{}) (interface{}, bool) {
-	l.m.Lock()
+	l.m.RLock()
 	v, f := l.c.Get(key)
-	l.m.Unlock()
+	l.m.RUnlock()
 	return v, f
 }
 
@@ -141,8 +141,8 @@ func (l *lockedCache) Remove(key interface{}) {
 }
 
 func (l *lockedCache) Len() int {
-	l.m.Lock()
+	l.m.RLock()
 	c := l.c.Len()
-	l.m.Unlock()
+	l.m.RUnlock()
 	return c
 }

--- a/inmem_benchmark_test.go
+++ b/inmem_benchmark_test.go
@@ -1,0 +1,132 @@
+package inmem_test
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/facebookgo/inmem"
+)
+
+var src = rand.NewSource(time.Now().UnixNano())
+
+const (
+	letterBytes   = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	keyLen        = 10
+	valLen        = 100
+	letterIdxBits = 6                    // 6 bits to represent a letter index
+	letterIdxMask = 1<<letterIdxBits - 1 // All 1-bits, as many as letterIdxBits
+	letterIdxMax  = 63 / letterIdxBits   // # of letter indices fitting in 63 bits
+)
+
+func RandString(n int) string {
+	b := make([]byte, n)
+	// A src.Int63() generates 63 random bits, enough for letterIdxMax characters!
+	for i, cache, remain := n-1, src.Int63(), letterIdxMax; i >= 0; {
+		if remain == 0 {
+			cache, remain = src.Int63(), letterIdxMax
+		}
+		if idx := int(cache & letterIdxMask); idx < len(letterBytes) {
+			b[i] = letterBytes[idx]
+			i--
+		}
+		cache >>= letterIdxBits
+		remain--
+	}
+
+	return string(b)
+}
+
+func benchmarkManyThings(b *testing.B, c inmem.Cache) {
+
+	var key = RandString(keyLen)
+
+	// cache miss
+	actual, found := c.Get(key)
+	if found == true || actual != nil {
+		b.Fail()
+	}
+
+	// add the value
+	val := RandString(valLen)
+	c.Add(key, val, time.Now().Add(time.Hour))
+
+	// cache hit
+	actual, found = c.Get(key)
+	if found == false || actual == nil || val != actual {
+		b.Fail()
+	}
+
+	// replace value
+	val = RandString(valLen)
+	c.Add(key, val, time.Now().Add(time.Hour))
+
+	// check for replace value
+	actual, found = c.Get(key)
+	if found == false || actual == nil || val != actual {
+		b.Fail()
+	}
+
+	// replace with expired
+	val = RandString(valLen)
+	c.Add(key, val, time.Now().Add(-1*time.Hour))
+
+	// try to get the expired key
+	actual, found = c.Get(key)
+	if found == true || actual != nil {
+		b.Fail()
+	}
+
+	// readd the value so we can remove it
+	c.Add(key, val, time.Now().Add(time.Hour))
+
+	// remove the key
+	c.Remove(key)
+
+	// try to get the empty key
+	actual, found = c.Get(key)
+	if found == true || actual != nil {
+		b.Fail()
+	}
+
+	// readd the original
+	c.Add(key, val, time.Now().Add(time.Hour))
+}
+
+func benchmarkLockedCache(cacheSize int, b *testing.B) {
+	cache := inmem.NewLocked(cacheSize)
+	for n := 0; n < b.N; n++ {
+		benchmarkManyThings(b, cache)
+	}
+}
+
+func benchmarkUnlockedCache(cacheSize int, b *testing.B) {
+	cache := inmem.NewUnlocked(cacheSize)
+	for n := 0; n < b.N; n++ {
+		benchmarkManyThings(b, cache)
+	}
+}
+
+func BenchmarkSmallUnlocked(b *testing.B) {
+	benchmarkUnlockedCache(10, b)
+}
+
+func BenchmarkSmallLocked(b *testing.B) {
+	benchmarkLockedCache(10, b)
+}
+
+func BenchmarkLargeUnlocked(b *testing.B) {
+	benchmarkUnlockedCache(1000, b)
+}
+
+func BenchmarkLargeLocked(b *testing.B) {
+	benchmarkUnlockedCache(1000, b)
+}
+
+func BenchmarkHugeUnlocked(b *testing.B) {
+	benchmarkUnlockedCache(100000, b)
+}
+
+func BenchmarkHugeLocked(b *testing.B) {
+	benchmarkLockedCache(100000, b)
+}


### PR DESCRIPTION
I'm interested to see what you think of these additions.    I thought a RWMutex might make more sense here.  this is just a start, and there are questions but I thought I would check it with you before proceeded to clean things up.

- Added a RWMutex
- One concern would be the removal of the expired element during a read.   Given that this is a non-element (for the purposes of the cache as it has expired) this may not be a terrible thing to do with a read lock.   Alternatively this could be deferred or done asynchronously and have it acquire a Write lock before removing.
- Added some benchmarks.   They need some more work, perhaps comparing between the RWMutex vs. Mutex